### PR TITLE
Bump Whatlang Package Dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Sergey Potapov <blake131313@gmail.com>"]
 
 [dependencies]
-whatlang = "0.5.0"
-libc = "0.2.29"
+whatlang = "0.12"
+libc = "0.2"
 
 [lib]
 name = "whatlang"


### PR DESCRIPTION
Bump the dependency on the `whatlang` crate to the latest minor version, and leave
the patch floating.