### PR TITLE
Expose `is_reliable`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub struct CInfo {
     lang: Lang,
     script: Script,
     confidence: f64,
+    is_reliable: bool,
 }
 
 #[no_mangle]
@@ -73,6 +74,7 @@ fn detect_internal(text: &[u8], cinfo: *mut CInfo) -> WhatlangStatus {
                         (*cinfo).lang = info.lang();
                         (*cinfo).script = info.script();
                         (*cinfo).confidence = info.confidence();
+                        (*cinfo).is_reliable = info.is_reliable();
                     }
                     WhatlangStatus::Ok
                 }

--- a/src/whatlang.h
+++ b/src/whatlang.h
@@ -145,6 +145,7 @@ struct whatlang_info {
   whatlang_lang_t lang;
   whatlang_script_t script;
   double confidence;
+  bool is_reliable;
 };
 
 // Detect the language in the input `text`


### PR DESCRIPTION
Update the C interface to expose the `is_reliable` property on
detections.